### PR TITLE
BUG: prevent garbage collection of viewer during startup.

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -243,11 +243,7 @@ def _run():
             layer_type=args.layer_type,
             **kwargs,
         )
-        # avoid regression; aggressively garbage collect _now_ to make sure we
-        # don't leak this again
-        import gc
 
-        gc.collect()
         run(gui_exceptions=True)
 
 


### PR DESCRIPTION
Here's an option for a test that makes sure we've got an additional reference, so that tests will fail on regression.  rather than calling `gc.collect()` in `napari.__main__` ... lemme know what you think